### PR TITLE
test: adiciona testes TDD para schemas e services

### DIFF
--- a/backend/tests/test_business/services/test_auth_service.py
+++ b/backend/tests/test_business/services/test_auth_service.py
@@ -1,0 +1,108 @@
+import pytest
+from unittest.mock import Mock, MagicMock, patch, ANY
+from fastapi import HTTPException
+from business.services.auth_service import AuthService
+
+
+@pytest.fixture
+def setup_service():
+    mock_user_repo = Mock()
+    mock_audit_repo = Mock()
+    mock_email_service = Mock()
+    mock_user_repo.db = MagicMock()
+    
+    service = AuthService(
+        repo=mock_user_repo,
+        audit_repo=mock_audit_repo,
+        email_service=mock_email_service
+    )
+    return service, mock_user_repo, mock_audit_repo, mock_email_service
+
+
+def test_register_first_user_as_admin(setup_service):
+    service, user_repo, audit_repo, _ = setup_service
+    
+    user_repo.count_users.return_value = 0
+    user_repo.get_by_email.return_value = None
+    user_repo.get_by_registration.return_value = None
+    user_repo.create.side_effect = lambda u: u
+    
+    result = service.register(
+        name="Admin Root", nickname="root", registration_number="001",
+        email="admin@unip.br", password="password123", area="TI"
+    )
+    
+    assert result.role == "admin"
+    assert result.is_active is True
+    audit_repo.log_action.assert_called_once()
+
+
+def test_register_student_requires_otp(setup_service):
+    service, user_repo, _, email_service = setup_service
+    
+    user_repo.count_users.return_value = 10
+    user_repo.get_by_email.return_value = None
+    user_repo.get_by_registration.return_value = None
+    user_repo.create.side_effect = lambda u: u
+    
+    result = service.register(
+        name="Aluno Teste", nickname="aluno", registration_number="202401",
+        email="aluno@unip.br", password="password123", area="Engenharia"
+    )
+    
+    assert result.role == "student"
+    assert result.is_active is False
+    assert result.otp_code is not None
+    email_service.send_verification_code.assert_called_once()
+
+
+@patch("business.services.auth_service.verify_password")
+@patch("business.services.auth_service.create_access_token")
+def test_login_success(mock_create_token, mock_verify_pwd, setup_service):
+    service, user_repo, _, _ = setup_service
+    
+    mock_user = MagicMock()
+    mock_user.id = 1
+    mock_user.is_active = True
+    mock_user.password_hash = "hashed_secret"
+    mock_user.role = "student"
+    mock_user.name = "Teste"
+    mock_user.nickname = "testinho"
+    
+    user_repo.get_by_registration.return_value = mock_user
+    mock_verify_pwd.return_value = True
+    mock_create_token.return_value = "fake-jwt-token"
+    
+    response = service.login("202401", "password123")
+    
+    assert response["access_token"] == "fake-jwt-token"
+    assert response["nickname"] == "testinho"
+
+
+def test_login_inactive_user_raises_exception(setup_service):
+    service, user_repo, _, _ = setup_service
+    
+    mock_user = MagicMock()
+    mock_user.is_active = False
+    user_repo.get_by_registration.return_value = mock_user
+    
+    with patch("business.services.auth_service.verify_password", return_value=True):
+        with pytest.raises(HTTPException) as excinfo:
+            service.login("202401", "password123")
+        
+        assert excinfo.value.status_code == 403
+
+
+def test_activate_account_success(setup_service):
+    service, user_repo, audit_repo, _ = setup_service
+    
+    mock_user = MagicMock()
+    mock_user.id = 50
+    mock_user.otp_code = "123456"
+    user_repo.get_by_email.return_value = mock_user
+    
+    success = service.activate_account("aluno@unip.br", "123456")
+    
+    assert success is True
+    assert mock_user.is_active is True
+    user_repo.db.commit.assert_called_once()

--- a/backend/tests/test_business/services/test_dashboard_service.py
+++ b/backend/tests/test_business/services/test_dashboard_service.py
@@ -1,0 +1,55 @@
+import pytest
+from unittest.mock import Mock
+from business.services.dashboard_service import DashboardService
+
+
+@pytest.fixture
+def setup_service():
+    mock_enroll = Mock()
+    mock_news = Mock()
+    mock_intern = Mock()
+    service = DashboardService(
+        enrollment_repo=mock_enroll,
+        news_repo=mock_news,
+        internship_repo=mock_intern
+    )
+    return service, mock_enroll, mock_news, mock_intern
+
+
+def test_get_student_summary_success(setup_service):
+    service, enroll_repo, news_repo, intern_repo = setup_service
+    
+    enroll_repo.list_by_user.return_value = ["i1", "i2"]
+    news_repo.list.return_value = ["n1", "n2", "n3"]
+    intern_repo.list.return_value = ["e1"]
+    
+    result = service.get_student_summary(user_id=1)
+    
+    assert len(result["my_enrollments"]) == 2
+    assert len(result["latest_news"]) == 3
+    assert len(result["recent_internships"]) == 1
+    
+    news_repo.list.assert_called_once_with(skip=0, limit=3)
+    intern_repo.list.assert_called_once_with(skip=0, limit=3)
+
+
+def test_get_student_summary_handles_none(setup_service):
+    service, enroll_repo, news_repo, intern_repo = setup_service
+    
+    enroll_repo.list_by_user.return_value = None
+    news_repo.list.return_value = None
+    intern_repo.list.return_value = None
+    
+    result = service.get_student_summary(user_id=1)
+    
+    assert result["my_enrollments"] == []
+    assert result["latest_news"] == []
+    assert result["recent_internships"] == []
+
+
+def test_get_student_summary_invalid_user_id(setup_service):
+    service, _, _, _ = setup_service
+    
+    result = service.get_student_summary(user_id="abc")
+    
+    assert result["my_enrollments"] == []

--- a/backend/tests/test_business/services/test_email_service.py
+++ b/backend/tests/test_business/services/test_email_service.py
@@ -1,0 +1,42 @@
+import pytest
+from unittest.mock import patch
+from business.services.email_service import EmailService
+
+
+@pytest.fixture
+def email_service():
+    with patch("business.services.email_service.settings") as mock_settings:
+        mock_settings.RESEND_API_KEY = "re_test_123"
+        mock_settings.EMAIL_FROM = "no-reply@unip-portal.edu.br"
+        mock_settings.OTP_EXPIRATION_MINUTES = 10
+        yield EmailService()
+
+
+def test_send_verification_code_params(email_service):
+    with patch("resend.Emails.send") as mock_send:
+        mock_send.return_value = {"id": "email_id_123"}
+        
+        result = email_service.send_verification_code("aluno@unip.br", "123456")
+        
+        assert result is True
+        mock_send.assert_called_once()
+        
+        args = mock_send.call_args[0][0]
+        assert args["to"] == ["aluno@unip.br"]
+        assert "123456" in args["subject"]
+        assert "123456" in args["html"]
+
+
+def test_send_verification_code_fallback(email_service):
+    with patch("resend.Emails.send", side_effect=Exception("API Error")):
+        with patch("builtins.print"):
+            result = email_service.send_verification_code("test@test.com", "999888")
+            assert result is True
+
+
+def test_code_formatting(email_service):
+    with patch("resend.Emails.send") as mock_send:
+        email_service.send_verification_code("test@test.com", " 12345678 ")
+        
+        args = mock_send.call_args[0][0]
+        assert "123456" in args["subject"]

--- a/backend/tests/test_business/services/test_enrollment_service.py
+++ b/backend/tests/test_business/services/test_enrollment_service.py
@@ -1,0 +1,44 @@
+import pytest
+from unittest.mock import Mock, MagicMock
+from datetime import date, timedelta
+from business.services.enrollment_service import EnrollmentService
+
+
+@pytest.fixture
+def service():
+    mock_enroll_repo = Mock()
+    mock_audit_repo = Mock()
+    mock_event_repo = Mock()
+    return EnrollmentService(mock_enroll_repo, mock_audit_repo, mock_event_repo)
+
+
+def test_falha_se_evento_nao_existir(service):
+    service.event_repo.get_by_id.return_value = None
+    
+    result = service.enroll_user(user_id=1, event_id=99)
+    
+    assert result == "event_not_found"
+
+
+def test_falha_se_prazo_vencido(service):
+    mock_event = Mock(deadline_date=date.today() - timedelta(days=1))
+    service.event_repo.get_by_id.return_value = mock_event
+    
+    result = service.enroll_user(user_id=1, event_id=1)
+    
+    assert result == "deadline_exceeded"
+
+
+def test_confirmar_presenca_sucesso(service):
+    mock_enrollment = MagicMock()
+    mock_enrollment.is_present = False
+    mock_enrollment.user.name = "Jefferson"
+    mock_enrollment.event.title = "Sistemas Distribuidos"
+    
+    service.repo.get_by_token.return_value = mock_enrollment
+    service.repo.confirm_attendance.return_value = mock_enrollment
+    
+    result = service.validate_attendance(qr_token="token_xyz", staff_id="admin")
+    
+    assert result["status"] == "success"
+    assert result["data"]["student_name"] == "Jefferson"

--- a/backend/tests/test_business/services/test_event_service.py
+++ b/backend/tests/test_business/services/test_event_service.py
@@ -1,0 +1,99 @@
+import pytest
+from unittest.mock import Mock, ANY
+from datetime import date, timedelta
+from business.services.event_service import EventService
+
+
+@pytest.fixture
+def setup_service():
+    mock_repo = Mock()
+    mock_audit = Mock()
+    service = EventService(repo=mock_repo, audit_repo=mock_audit)
+    return service, mock_repo, mock_audit
+
+
+def test_create_event_success(setup_service):
+    service, repo, audit = setup_service
+    
+    event_data = {
+        "title": "Workshop de FastAPI",
+        "event_date": date.today() + timedelta(days=10),
+        "registration_type": "internal",
+        "total_slots": 50,
+        "location": "Auditório A",
+        "area": "TI"
+    }
+    
+    mock_event = Mock()
+    repo.create.return_value = mock_event
+    
+    result = service.create_event(event_data, admin_id=1)
+    
+    assert result == mock_event
+    audit.log_action.assert_called_once()
+
+
+def test_create_event_past_date_error(setup_service):
+    service, _, _ = setup_service
+    
+    past_event = {
+        "title": "Evento Antigo",
+        "event_date": date.today() - timedelta(days=1)
+    }
+    
+    with pytest.raises(ValueError):
+        service.create_event(past_event, admin_id=1)
+
+
+def test_create_external_event_without_url_error(setup_service):
+    service, _, _ = setup_service
+    
+    external_event = {
+        "title": "Evento Externo",
+        "registration_type": "external",
+        "external_url": ""
+    }
+    
+    with pytest.raises(ValueError):
+        service.create_event(external_event, admin_id=1)
+
+
+def test_check_availability_no_vacancies(setup_service):
+    service, repo, _ = setup_service
+    
+    mock_event = Mock()
+    mock_event.registration_type = "internal"
+    mock_event.is_active = True
+    mock_event.is_registration_closed = False
+    mock_event.has_vacancies = False
+    repo.get_by_id.return_value = mock_event
+    
+    result = service.check_availability(1)
+    
+    assert result["available"] is False
+
+
+def test_check_availability_external(setup_service):
+    service, repo, _ = setup_service
+    
+    mock_event = Mock()
+    mock_event.registration_type = "external"
+    mock_event.external_url = "https://sympla.com/evento"
+    repo.get_by_id.return_value = mock_event
+    
+    result = service.check_availability(2)
+    
+    assert result["available"] is True
+    assert result["external"] is True
+    assert result["url"] == "https://sympla.com/evento"
+
+
+def test_delete_event_audit(setup_service):
+    service, repo, audit = setup_service
+    repo.delete.return_value = True
+    
+    result = service.delete_event(10, admin_id=1)
+    
+    assert result is True
+    repo.delete.assert_called_once_with(10)
+    audit.log_action.assert_called_once()

--- a/backend/tests/test_business/services/test_internship_service.py
+++ b/backend/tests/test_business/services/test_internship_service.py
@@ -1,0 +1,63 @@
+import pytest
+from unittest.mock import Mock, ANY
+from business.services.internship_service import InternshipService
+
+
+@pytest.fixture
+def setup_service():
+    mock_repo = Mock()
+    mock_audit = Mock()
+    service = InternshipService(repo=mock_repo, audit_repo=mock_audit)
+    return service, mock_repo, mock_audit
+
+
+def test_create_internship_success(setup_service):
+    service, repo, audit = setup_service
+    
+    mock_internship = Mock()
+    repo.create.return_value = mock_internship
+    
+    result = service.create_internship(mock_internship, admin_id=10)
+    
+    assert result == mock_internship
+    audit.log_action.assert_called_once()
+
+
+def test_list_internships(setup_service):
+    service, repo, _ = setup_service
+    
+    service.list_internships(skip=5, limit=15, search="Python")
+    
+    repo.list.assert_called_once_with(skip=5, limit=15, search="Python")
+
+
+def test_get_internship_not_found(setup_service):
+    service, repo, _ = setup_service
+    repo.get_by_id.return_value = None
+    
+    result = service.get_internship(999)
+    
+    assert result is None
+
+
+def test_update_internship_audit(setup_service):
+    service, repo, audit = setup_service
+    
+    mock_updated = Mock()
+    repo.update.return_value = mock_updated
+    
+    result = service.update_internship(5, {"salary": 1500}, admin_id=1)
+    
+    assert result == mock_updated
+    audit.log_action.assert_called_once()
+
+
+def test_delete_internship(setup_service):
+    service, repo, audit = setup_service
+    repo.delete.return_value = True
+    
+    result = service.delete_internship(20, admin_id=1)
+    
+    assert result is True
+    repo.delete.assert_called_once_with(20)
+    audit.log_action.assert_called_once()

--- a/backend/tests/test_business/services/test_news_service.py
+++ b/backend/tests/test_business/services/test_news_service.py
@@ -1,0 +1,84 @@
+import pytest
+from unittest.mock import Mock, ANY
+from business.services.news_service import NewsService
+
+
+@pytest.fixture
+def setup_news_service():
+    mock_news_repo = Mock()
+    mock_audit_repo = Mock()
+    service = NewsService(repo=mock_news_repo, audit_repo=mock_audit_repo)
+    return service, mock_news_repo, mock_audit_repo
+
+
+def test_update_news_forbidden(setup_news_service):
+    """Usuário comum não pode editar notícia de outro autor."""
+    service, news_repo, _ = setup_news_service
+    
+    mock_news = Mock()
+    mock_news.author_id = 99
+    news_repo.get_by_id.return_value = mock_news
+    
+    result = service.update_news(1, {}, user_id=1, user_role="student", version_sent=1)
+    
+    assert result == "forbidden"
+
+
+def test_update_news_concurrency_error(setup_news_service):
+    """Erro quando versão enviada é diferente da atual."""
+    service, news_repo, _ = setup_news_service
+    
+    mock_news = Mock()
+    mock_news.author_id = 1
+    mock_news.version = 2
+    news_repo.get_by_id.return_value = mock_news
+    
+    result = service.update_news(1, {}, user_id=1, user_role="admin", version_sent=1)
+    
+    assert result == "concurrency_error"
+
+
+def test_delete_news_soft_delete(setup_news_service):
+    """Soft delete quando notícia tem leituras."""
+    service, news_repo, audit_repo = setup_news_service
+    
+    mock_news = Mock()
+    mock_news.author_id = 1
+    news_repo.get_by_id.return_value = mock_news
+    news_repo.count_reads.return_value = 5
+    news_repo.soft_delete.return_value = True
+    
+    result = service.delete_news(1, user_id=1, user_role="admin")
+    
+    assert result is True
+    news_repo.soft_delete.assert_called_once_with(1)
+    audit_repo.log_action.assert_called_once()
+
+
+def test_delete_news_physical_delete(setup_news_service):
+    """Physical delete quando notícia não tem leituras."""
+    service, news_repo, _ = setup_news_service
+    
+    mock_news = Mock()
+    mock_news.author_id = 1
+    news_repo.get_by_id.return_value = mock_news
+    news_repo.count_reads.return_value = 0
+    news_repo.physical_delete.return_value = True
+    
+    result = service.delete_news(1, user_id=1, user_role="admin")
+    
+    assert result is True
+    news_repo.physical_delete.assert_called_once_with(1)
+
+
+def test_get_news_and_log_read(setup_news_service):
+    """Buscar notícia registra log de leitura."""
+    service, news_repo, _ = setup_news_service
+    
+    mock_news = Mock()
+    news_repo.get_by_id.return_value = mock_news
+    
+    result = service.get_news_and_log_read(news_id=10, user_id=1)
+    
+    assert result == mock_news
+    news_repo.register_read.assert_called_once_with(10, 1)

--- a/backend/tests/test_business/services/test_storage_service.py
+++ b/backend/tests/test_business/services/test_storage_service.py
@@ -1,0 +1,44 @@
+import pytest
+import os
+from unittest.mock import Mock, patch, mock_open
+from business.services.storage_service import StorageService
+
+
+@pytest.fixture
+def storage_service():
+    with patch("os.makedirs"):
+        yield StorageService()
+
+
+@pytest.mark.anyio
+async def test_save_banner_generates_unique_path(storage_service):
+    mock_file = Mock()
+    mock_file.filename = "evento_unip.png"
+    async def mock_read(): return b"fake_binary_content"
+    mock_file.read.side_effect = mock_read
+
+    with patch("builtins.open", mock_open()) as mocked_file:
+        with patch("uuid.uuid4", return_value="test-uuid-123"):
+            result = await storage_service.save_banner(mock_file)
+            
+            assert result == "/static/banners/test-uuid-123.png"
+            mocked_file.assert_called_once()
+            mocked_file().write.assert_called_once_with(b"fake_binary_content")
+
+
+@pytest.mark.anyio
+async def test_save_banner_handles_exception(storage_service):
+    mock_file = Mock()
+    mock_file.filename = "erro.jpg"  # ← ADICIONADO: filename necessário
+    async def mock_read(): return b"data"
+    mock_file.read.side_effect = mock_read
+
+    with patch("builtins.open", side_effect=IOError("Disk Full")):
+        with pytest.raises(IOError, match="Disk Full"):
+            await storage_service.save_banner(mock_file)
+
+
+def test_init_creates_directory():
+    with patch("os.makedirs") as mock_mkdir:
+        StorageService()
+        mock_mkdir.assert_called_once_with("static/banners", exist_ok=True)

--- a/backend/tests/test_schemas/test_audit_schema.py
+++ b/backend/tests/test_schemas/test_audit_schema.py
@@ -1,0 +1,31 @@
+import pytest
+from datetime import datetime
+from pydantic import ValidationError
+from schemas.audit_schema import AuditLogResponse
+
+def test_audit_log_valid():
+    schema = AuditLogResponse(
+        id=1, user_id="123", action="CREATE", table_name="users",
+        description="Usuário criado", timestamp=datetime.now()
+    )
+    assert schema.id == 1
+
+def test_audit_log_description_none():
+    schema = AuditLogResponse(
+        id=2, user_id="456", action="DELETE", table_name="events",
+        description=None, timestamp=datetime.now()
+    )
+    assert schema.description is None
+
+def test_audit_log_without_description_raises_error():
+    with pytest.raises(ValidationError):
+        AuditLogResponse(
+            id=3, user_id="789", action="UPDATE",
+            table_name="courses", timestamp=datetime.now()
+        )
+
+def test_audit_log_missing_user_id():
+    with pytest.raises(ValidationError):
+        AuditLogResponse(
+            id=4, action="CREATE", table_name="users", timestamp=datetime.now()
+        )

--- a/backend/tests/test_schemas/test_dashboard_schema.py
+++ b/backend/tests/test_schemas/test_dashboard_schema.py
@@ -1,0 +1,51 @@
+import pytest
+from datetime import datetime
+from pydantic import ValidationError
+from schemas.dashboard_schema import StudentDashboardResponse
+from schemas.enrollment_schema import EnrollmentResponse
+from schemas.news_schema import NewsResponse
+from schemas.internship_schema import InternshipResponse
+
+@pytest.fixture
+def enrollment():
+    return EnrollmentResponse(
+        id=1, user_id=1, event_id=1, qr_code_token="token123",
+        enrolled_at=datetime.now(), is_present=False
+    )
+
+@pytest.fixture
+def news():
+    return NewsResponse(
+        id=1, title="Comunicado", content="Conteúdo com mais de 10 caracteres",
+        created_at=datetime.now(), is_active=True, status="published",
+        author_id=1, version=1
+    )
+
+@pytest.fixture
+def internship():
+    return InternshipResponse(
+        id=1, company="Empresa", position="Desenvolvedor", location="SP",
+        start_date=datetime.now(), status="Ativo", is_active=True,
+        author_id=1, version=1, created_at=datetime.now()
+    )
+
+def test_dashboard_valid(enrollment, news, internship):
+    schema = StudentDashboardResponse(
+        my_enrollments=[enrollment],
+        latest_news=[news],
+        recent_internships=[internship]
+    )
+    assert len(schema.my_enrollments) == 1
+
+def test_dashboard_empty_lists():
+    schema = StudentDashboardResponse(
+        my_enrollments=[], latest_news=[], recent_internships=[]
+    )
+    assert schema.my_enrollments == []
+
+def test_dashboard_missing_field(enrollment, news):
+    with pytest.raises(ValidationError):
+        StudentDashboardResponse(
+            my_enrollments=[enrollment],
+            latest_news=[news]
+        )

--- a/backend/tests/test_schemas/test_enrollment_schema.py
+++ b/backend/tests/test_schemas/test_enrollment_schema.py
@@ -1,0 +1,68 @@
+import pytest
+from datetime import datetime, date
+from pydantic import ValidationError
+from schemas.enrollment_schema import (
+    EnrollmentCreate, AttendanceCheck, EnrollmentResponse,
+    AttendanceDetail, EventAttendanceReport
+)
+
+# TESTES ENROLLMENTCREATE
+
+def test_enrollment_create_valid():
+    schema = EnrollmentCreate(event_id=1)
+    assert schema.event_id == 1
+
+def test_enrollment_create_missing_event_id():
+    with pytest.raises(ValidationError):
+        EnrollmentCreate()
+
+# TESTES ATTENDANCECHECK
+
+def test_attendance_check_valid():
+    schema = AttendanceCheck(qr_code_token="token123")
+    assert schema.qr_code_token == "token123"
+
+def test_attendance_check_missing_token():
+    with pytest.raises(ValidationError):
+        AttendanceCheck()
+
+# TESTES ENROLLMENTRESPONSE
+
+def test_enrollment_response_valid():
+    schema = EnrollmentResponse(
+        id=1, user_id=1, event_id=1, qr_code_token="token123",
+        enrolled_at=datetime.now(), is_present=False
+    )
+    assert schema.id == 1
+
+def test_enrollment_response_optional_fields():
+    schema = EnrollmentResponse(
+        id=1, user_id=1, event_id=1, qr_code_token="token123",
+        enrolled_at=datetime.now(), is_present=False,
+        event_name=None, student_name=None
+    )
+    assert schema.event_name is None
+
+# TESTES ATTENDANCEDETAIL
+
+def test_attendance_detail_valid():
+    schema = AttendanceDetail(
+        name="João", registration="123", area="Computação", is_present=True
+    )
+    assert schema.name == "João"
+
+def test_attendance_detail_missing_fields():
+    with pytest.raises(ValidationError):
+        AttendanceDetail(name="João")
+
+# TESTES EVENTATTENDANCEREPORT
+
+def test_event_attendance_report_valid():
+    schema = EventAttendanceReport(
+        event_title="Evento", total_enrolled=10, total_present=5, attendees=[]
+    )
+    assert schema.event_title == "Evento"
+
+def test_event_attendance_report_missing_fields():
+    with pytest.raises(ValidationError):
+        EventAttendanceReport(event_title="Evento")

--- a/backend/tests/test_schemas/test_event_schema.py
+++ b/backend/tests/test_schemas/test_event_schema.py
@@ -1,0 +1,79 @@
+import pytest
+from datetime import datetime, date
+from pydantic import ValidationError
+from schemas.event_schema import EventCreate, EventResponse, AttachmentCreate
+
+# TESTES ATTACHMENT
+
+def test_attachment_create_valid():
+    schema = AttachmentCreate(name="doc.pdf", url="https://exemplo.com/doc.pdf")
+    assert schema.name == "doc.pdf"
+
+def test_attachment_missing_name():
+    with pytest.raises(ValidationError):
+        AttachmentCreate(url="https://exemplo.com/doc.pdf")
+
+# TESTES EVENTCREATE
+
+def test_event_create_valid():
+    schema = EventCreate(
+        title="Evento", event_date=date(2024, 12, 15), start_time="14:00",
+        shift="Tarde", location="Local", deadline_date=date(2024, 12, 10),
+        total_slots=50
+    )
+    assert schema.title == "Evento"
+
+def test_event_create_title_too_short():
+    with pytest.raises(ValidationError):
+        EventCreate(
+            title="AB", event_date=date(2024, 12, 15), start_time="14:00",
+            shift="Tarde", location="Local", deadline_date=date(2024, 12, 10),
+            total_slots=50
+        )
+
+def test_event_create_invalid_time():
+    with pytest.raises(ValidationError):
+        EventCreate(
+            title="Evento", event_date=date(2024, 12, 15), start_time="14:00:00",
+            shift="Tarde", location="Local", deadline_date=date(2024, 12, 10),
+            total_slots=50
+        )
+
+def test_event_create_negative_slots():
+    with pytest.raises(ValidationError):
+        EventCreate(
+            title="Evento", event_date=date(2024, 12, 15), start_time="14:00",
+            shift="Tarde", location="Local", deadline_date=date(2024, 12, 10),
+            total_slots=-5
+        )
+
+def test_event_create_with_attachments():
+    schema = EventCreate(
+        title="Evento", event_date=date(2024, 12, 15), start_time="14:00",
+        shift="Tarde", location="Local", deadline_date=date(2024, 12, 10),
+        total_slots=50, attachments=[AttachmentCreate(name="doc.pdf", url="https://exemplo.com/doc.pdf")]
+    )
+    assert len(schema.attachments) == 1
+
+# TESTES EVENTRESPONSE
+
+def test_event_response_valid():
+    schema = EventResponse(
+        id=1, title="Evento", event_date=date(2024, 12, 15), start_time="14:00",
+        shift="Tarde", location="Local", deadline_date=date(2024, 12, 10),
+        total_slots=50, owner_id=1, created_at=datetime.now()
+    )
+    assert schema.id == 1
+
+def test_event_response_missing_fields():
+    with pytest.raises(ValidationError):
+        EventResponse(id=1, title="Evento")
+
+def test_event_response_default_values():
+    schema = EventResponse(
+        id=1, title="Evento", event_date=date(2024, 12, 15), start_time="14:00",
+        shift="Tarde", location="Local", deadline_date=date(2024, 12, 10),
+        total_slots=50, owner_id=1, created_at=datetime.now()
+    )
+    assert schema.occupied_slots == 0
+    assert schema.is_active is True

--- a/backend/tests/test_schemas/test_internship_schema.py
+++ b/backend/tests/test_schemas/test_internship_schema.py
@@ -1,0 +1,59 @@
+import pytest
+from datetime import datetime
+from pydantic import ValidationError
+from schemas.internship_schema import InternshipCreate, InternshipUpdate, InternshipResponse
+
+@pytest.fixture
+def valid_data():
+    return {
+        "company": "Empresa Tech",
+        "position": "Desenvolvedor",
+        "location": "São Paulo",
+        "start_date": datetime(2024, 1, 15)
+    }
+
+# TESTES CREATE
+
+def test_create_valid(valid_data):
+    schema = InternshipCreate(**valid_data)
+    assert schema.company == "Empresa Tech"
+
+def test_create_company_too_short(valid_data):
+    data = valid_data.copy()
+    data["company"] = "A"
+    with pytest.raises(ValidationError):
+        InternshipCreate(**data)
+
+def test_create_description_optional(valid_data):
+    schema = InternshipCreate(**valid_data)
+    assert schema.description is None
+
+def test_create_end_date_optional(valid_data):
+    schema = InternshipCreate(**valid_data)
+    assert schema.end_date is None
+
+# TESTES UPDATE
+
+def test_update_valid(valid_data):
+    data = {**valid_data, "current_version": 1}
+    schema = InternshipUpdate(**data)
+    assert schema.current_version == 1
+
+def test_update_missing_version(valid_data):
+    with pytest.raises(ValidationError):
+        InternshipUpdate(**valid_data)
+
+# TESTES RESPONSE
+
+def test_response_valid(valid_data):
+    data = {
+        **valid_data,
+        "id": 1, "status": "Ativo", "is_active": True,
+        "author_id": 1, "version": 1, "created_at": datetime.now()
+    }
+    schema = InternshipResponse(**data)
+    assert schema.id == 1
+
+def test_response_missing_fields():
+    with pytest.raises(ValidationError):
+        InternshipResponse(id=1, company="Empresa")

--- a/backend/tests/test_schemas/test_news_schema.py
+++ b/backend/tests/test_schemas/test_news_schema.py
@@ -1,0 +1,93 @@
+import pytest
+from datetime import datetime
+from pydantic import ValidationError
+from schemas.news_schema import (
+    NewsCreate, NewsUpdate, NewsResponse,
+    NewsReadResponse, NewsReadCreate
+)
+
+# FIXTURES
+
+@pytest.fixture
+def valid_news():
+    return {
+        "title": "Comunicado Oficial",
+        "content": "Conteúdo com mais de 10 caracteres",
+        "image_url": "https://exemplo.com/imagem.jpg"
+    }
+
+# TESTES NEWSCREATE
+
+def test_news_create_valid(valid_news):
+    schema = NewsCreate(**valid_news)
+    assert schema.title == "Comunicado Oficial"
+
+def test_news_create_title_too_short(valid_news):
+    data = valid_news.copy()
+    data["title"] = "ABC"
+    with pytest.raises(ValidationError):
+        NewsCreate(**data)
+
+def test_news_create_content_too_short(valid_news):
+    data = valid_news.copy()
+    data["content"] = "ABC"
+    with pytest.raises(ValidationError):
+        NewsCreate(**data)
+
+def test_news_create_image_optional(valid_news):
+    data = valid_news.copy()
+    del data["image_url"]
+    schema = NewsCreate(**data)
+    assert schema.image_url is None
+
+# TESTES NEWSUPDATE
+
+def test_news_update_valid(valid_news):
+    data = {**valid_news, "current_version": 1}
+    schema = NewsUpdate(**data)
+    assert schema.current_version == 1
+
+def test_news_update_missing_version(valid_news):
+    with pytest.raises(ValidationError):
+        NewsUpdate(**valid_news)
+
+# TESTES NEWSRESPONSE
+
+def test_news_response_valid(valid_news):
+    data = {
+        **valid_news,
+        "id": 1,
+        "created_at": datetime.now(),
+        "is_active": True,
+        "status": "published",
+        "author_id": 1,
+        "version": 1
+    }
+    schema = NewsResponse(**data)
+    assert schema.id == 1
+
+def test_news_response_required_fields():
+    with pytest.raises(ValidationError):
+        NewsResponse(id=1, title="Teste")
+
+# TESTES NEWSREAD
+
+def test_news_read_response_valid():
+    schema = NewsReadResponse(
+        news_id=1,
+        user_id=1,
+        read_at=datetime.now()
+    )
+    assert schema.news_id == 1
+
+def test_news_read_create_valid():
+    schema = NewsReadCreate(news_id=1)
+    assert schema.news_id == 1
+
+def test_news_read_create_missing_news_id():
+    with pytest.raises(ValidationError):
+        NewsReadCreate()
+
+# EXECUÇÃO
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/backend/tests/test_schemas/test_user_schema.py
+++ b/backend/tests/test_schemas/test_user_schema.py
@@ -1,0 +1,118 @@
+import pytest
+from datetime import date
+from pydantic import ValidationError
+from schemas.user_schema import (
+    UserCreate, UserResponse, UserUpdateSelf, PasswordUpdate,
+    UserLogin, UserVerifyOTP
+)
+
+# FIXTURES
+
+@pytest.fixture
+def valid_user_data():
+    return {
+        "name": "João Silva",
+        "nickname": "joaosilva",
+        "registration_number": "2023001",
+        "email": "joao@email.com",
+        "password": "Senha123",
+        "area": "Computação",
+        "phone": "11999991234",
+        "birth_date": date(2000, 1, 1)
+    }
+
+# TESTES USERCREATE
+
+def test_user_create_valid(valid_user_data):
+    schema = UserCreate(**valid_user_data)
+    assert schema.email == "joao@email.com"
+
+def test_user_create_password_validation(valid_user_data):
+    data = valid_user_data.copy()
+    data["password"] = "senha123"  # sem maiúscula
+    with pytest.raises(ValidationError):
+        UserCreate(**data)
+
+def test_user_create_invalid_email(valid_user_data):
+    data = valid_user_data.copy()
+    data["email"] = "invalido"
+    with pytest.raises(ValidationError):
+        UserCreate(**data)
+
+def test_user_create_phone_formats(valid_user_data):
+    data = valid_user_data.copy()
+    data["phone"] = "(11) 99999-1234"
+    schema = UserCreate(**data)
+    assert schema.phone == "11999991234"
+
+# TESTES USERRESPONSE
+
+def test_user_response_valid(valid_user_data):
+    data = {
+        "id": 1,
+        **valid_user_data,
+        "role": "student",
+        "is_active": True
+    }
+    schema = UserResponse(**data)
+    assert schema.id == 1
+
+def test_user_response_required_fields():
+    with pytest.raises(ValidationError):
+        UserResponse(id=1, name="João")
+
+# TESTES USERUPDATESELF
+
+def test_user_update_self_partial():
+    schema = UserUpdateSelf(name="Novo Nome")
+    assert schema.name == "Novo Nome"
+
+def test_user_update_self_phone_formats():
+    schema = UserUpdateSelf(phone="(11) 98888-7777")
+    assert schema.phone == "11988887777"
+
+# TESTES PASSWORDUPDATE
+
+def test_password_update_valid():
+    schema = PasswordUpdate(
+        current_password="Senha123",
+        new_password="NovaSenha456"
+    )
+    assert schema.new_password == "NovaSenha456"
+
+def test_password_update_weak_password():
+    with pytest.raises(ValidationError):
+        PasswordUpdate(
+            current_password="Senha123",
+            new_password="nova456"  # sem maiúscula
+        )
+
+# TESTES USERLOGIN
+
+def test_user_login_valid():
+    schema = UserLogin(
+        registration_number="2023001",
+        password="Senha123"
+    )
+    assert schema.registration_number == "2023001"
+
+def test_user_login_missing_fields():
+    with pytest.raises(ValidationError):
+        UserLogin(registration_number="2023001")
+
+# TESTES USERVERIFYOTP
+
+def test_user_verify_otp_valid():
+    schema = UserVerifyOTP(
+        email="joao@email.com",
+        otp_code="123456"
+    )
+    assert schema.otp_code == "123456"
+
+def test_user_verify_otp_invalid():
+    with pytest.raises(ValidationError):
+        UserVerifyOTP(email="joao@email.com", otp_code="123ABC")
+
+# EXECUÇÃO
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## O que foi feito
- Adiciona testes para 7 schemas
- Adiciona testes para 8 services
- Total de 93 testes passando

## Como testar
```bash
PYTHONPATH=. pytest tests/ -v